### PR TITLE
Add .env files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# Override this by creating a file named
+# `.env.local` in the repo root and assigning overriding
+# values to keys in that file.
+# https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env
+REACT_APP_HOST=aurmr-control

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Ignore local ENV overrides
+.env.local

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 > it means that the `HOST` env variable needs to be set. For testing run `HOST=localhost` in the current shell before `yarn start` to run the server locally, otherwise
 > `HOST` should be set to `aurmr-control` (assuming you're on the `aurmr-control` workstation) so that other things can find
 > the server.
+> To do this more permanently create a `.env.local` file in the repo root
+> and add a line `HOST=some_host` there (replacing `some_host` with your hostname)
 
 ## How to start graphql playground? 
 For Your Information: graphql playground is something that runs on `localhost:4000` that provides a space for you to write and test out queries and mutations before making it official and adding it to your app. It also provides you a nice UI that prompts you suggestions when writing your queries and mutations. To get this working, please follow the steps below.


### PR DESCRIPTION
Currently the HOST environment variable needs to be set to use the server.

The `aurmr-control` workstation previously just had an unmentioned `user.bashrc` that was handling setting this up when you `activate webinterface_ws` (note it relies on custom `aurmr` CLI).

It probably makes more sense to make this more apparent and also localized to the repo (rather than needing to pollute conda environment variables). The `.env` files help to accomplish this.